### PR TITLE
docs: cover recent undocumented setup & behavioral changes

### DIFF
--- a/content/en/docs/ecommerce/digital_notifications/index.md
+++ b/content/en/docs/ecommerce/digital_notifications/index.md
@@ -1,0 +1,44 @@
+---
+title: "Digital notifications for e-commerce orders"
+description: "Consolidated NP Designer notification emails for e-commerce virtual items, including vouchers, tickets, coupons, and attraction wallets."
+lead: ""
+date: 2026-07-07T00:00:00+00:00
+lastmod: 2026-07-07T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: ""
+    identifier: "digital_notifications-2f6b8c1e9a4d47b3b0e2c7d915840a63"
+weight: 335
+toc: true
+type: docs
+---
+
+When an e-commerce order contains virtual items, the system can send the customer a single consolidated **digital notification** email built with NP Designer. The email includes a manifest — the *View Your Digital Products* link — that gives the customer access to the digital products they bought.
+
+## Supported virtual items
+
+A digital notification for an e-commerce order can include:
+
+- **Vouchers**
+- **Tickets**
+- **Coupons**
+- **Attraction wallets**
+
+Coupons and attraction wallets are included for e-commerce orders. Where a ticket is bundled inside an attraction wallet, it is presented as part of that wallet rather than as a separate ticket.
+
+{{< alert icon="📝" text="Memberships are not part of this notification. Membership purchases keep their own welcome/notification flow."/>}}
+
+## Job queue
+
+E-commerce digital notifications are sent by the **NPR EcomDigitalNotifJQ** job queue. Make sure this job queue is running so notifications are delivered promptly after an order is processed.
+
+## Exclude items from the manifest
+
+On the **NPR Digital Notification Setup** page you can control which item types appear in the manifest link:
+
+- **Exclude Vouchers From Manifest**
+- **Exclude Tickets From Manifest**
+
+Enabling an exclude flag removes that item type from the *View Your Digital Products* manifest only. The item still appears in the order items table in the email body. The ticket exclusion applies to standalone tickets — tickets that are bundled inside an attraction wallet are still shown as part of the wallet.

--- a/content/en/docs/ecommerce/entria/how-to/checkout_language/index.md
+++ b/content/en/docs/ecommerce/entria/how-to/checkout_language/index.md
@@ -1,0 +1,33 @@
+---
+title: "Entria checkout language and locale"
+description: "How the cart locale drives the checkout language and how it maps to the order and session."
+lead: ""
+date: 2026-07-07T00:00:00+00:00
+lastmod: 2026-07-07T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: ""
+    identifier: "checkout_language-entria-4e8a1c26b93d47f0ad51c7e208136af9"
+weight: 343
+toc: true
+type: docs
+---
+
+Entria checkout derives its language from the cart's locale, so a shopper continues in the same language they were browsing in.
+
+## How the language is resolved
+
+The cart/order locale (for example `da-DK`) is the source of truth. The checkout takes the base language part of that locale (`da-DK` → `da`) to decide which language to display. If the cart has no usable locale, the checkout falls back to the store's locale, and finally to English.
+
+Currently the supported checkout languages are **English (`en`)** and **Danish (`da`)**. A locale that resolves to any other language logs a warning and falls back to English.
+
+## Locale versus store formatting
+
+Two locales are involved and they serve different purposes:
+
+- **Store locale** controls number and currency formatting.
+- **Cart/order locale** controls the interface language and date formatting.
+
+When you set up a store, make sure its locale and the cart locales you expect are consistent with the supported languages above, so shoppers get both correct formatting and a translated interface.

--- a/content/en/docs/ecommerce/entria/how-to/order_import/index.md
+++ b/content/en/docs/ecommerce/entria/how-to/order_import/index.md
@@ -1,0 +1,30 @@
+---
+title: "Entria order import and sync state"
+description: "How Entria orders are imported per store and where the last import time is tracked."
+lead: ""
+date: 2026-07-07T00:00:00+00:00
+lastmod: 2026-07-07T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: ""
+    identifier: "order_import-entria-7c1b9e40a52d4f6cb83e1a7d0296f5c1"
+weight: 342
+toc: true
+type: docs
+---
+
+Entria orders are imported into Business Central per store by the Entria order import job queue. This article explains how the import tracks its progress.
+
+## Import sync state
+
+The import records how far it has progressed for each store in a dedicated **Entria store sync state**. The progress timestamp is now saved **after each processed page of orders** rather than only at the end of a run. If an import is interrupted, the next run continues from the last successfully processed page instead of reprocessing the whole batch.
+
+To avoid missing orders around the boundary between runs, the incremental import re-checks a short overlap window before the last recorded time.
+
+## Last Orders Imported At
+
+The **Last Orders Imported At** value on the **Entria Store Card** shows when orders were last imported for that store. It reads from the store sync state.
+
+{{< alert icon="📝" text="The <b>Last Orders Imported At</b> field can be edited manually to move the import marker, but not while the order import job is running for that store."/>}}

--- a/content/en/docs/ecommerce/entria/how-to/voucher_checkout/index.md
+++ b/content/en/docs/ecommerce/entria/how-to/voucher_checkout/index.md
@@ -21,6 +21,15 @@ Use this guide when you want customers to apply vouchers directly in Entria chec
 
 Before vouchers can be used in checkout, the voucher functionality must be enabled in the Entria backend and connected to a configured voucher payment provider and voucher collection endpoint. Your integration must also be able to authenticate toward Business Central APIs, for example through BC API key configuration in environments where that is required. Finally, make sure voucher currency and checkout currency are compatible.
 
+## Limit the amount on voucher products
+
+For voucher products that let the shopper choose a value (open-amount vouchers), you can constrain the allowed amount in the product configuration:
+
+- **Min Price** and **Max Price** set the lowest and highest amount a shopper can enter.
+- **Price Steps** define a fixed list of allowed amounts (for example 100, 250, 500).
+
+If price steps are defined, the shopper must pick one of the listed amounts — the min/max range is not used. If no price steps are defined, a custom amount is accepted as long as it is within the min/max range. Amounts that break these rules are rejected when the voucher line is added to the cart.
+
 ## Apply a voucher in checkout
 
 When a customer reaches the payment step in checkout, they can enter the voucher code in the voucher input field and apply it. If the voucher is valid, checkout updates immediately and deducts the voucher amount from the order total.

--- a/content/en/docs/ecommerce/shopify/explanation/getting_orders/index.md
+++ b/content/en/docs/ecommerce/shopify/explanation/getting_orders/index.md
@@ -58,6 +58,18 @@ Customers are selected by using the **Customer search routine**. During the orde
    For more information, refer to the article on [<ins>E-commerce stores<ins>]({{< ref "../../how-to/sales_order_setup/index.md" >}}).
 
 
+## Reservation token on ticket orders
+
+When an order contains reserved tickets, the ticket reservation token is written back onto the Shopify order so downstream systems can read it. It is stored in three places on the order:
+
+- As an order **custom attribute** with the key `reservationToken`.
+- As an order **metafield** `np-ticket.reservation_token`.
+- As an app-owned order **metafield** `$app:np-ticket.np-ticket-reservation-token`.
+
+In addition, the metafield `np-ticket.line_items_data` holds a JSON map that links each Shopify order line item to its reserved ticket line, so consumers can match order lines to reservations.
+
+Anything reading the order data downstream (apps, reports, integrations) can therefore retrieve the reservation token and the line-item mapping directly from the order.
+
 ### Next steps
 
 - [<ins>Send data back to Shopify<ins>]({{< ref "../send_data_back/index.md" >}})

--- a/content/en/docs/hospitality/explanation/routing_profiles/index.md
+++ b/content/en/docs/hospitality/explanation/routing_profiles/index.md
@@ -49,3 +49,7 @@ Each order is sent to the kitchen in the form of a waiter request for meal prepa
   ![restaurant_setup](Images/restaurant_setup.PNG)
 
 In the **Print Template Output Setup** you can set the printer on which the templates are printed. The output printers also need to be physically configured in each kitchen station.
+
+## Routing profile required for menu items
+
+An item can only be added to a restaurant menu if its item card has a **Rest. Item Routing Profile** set. If the field is blank, adding or changing the item on a menu is blocked with an error asking you to set the item's routing profile first. This ensures every menu item has kitchen routing and is not silently skipped when orders are sent to the kitchen. See also [<ins>Restaurant menu items<ins>]({{< ref "../../reference/menu_items/index.md" >}}).

--- a/content/en/docs/hospitality/how-to/qr_food_order/index.md
+++ b/content/en/docs/hospitality/how-to/qr_food_order/index.md
@@ -1,0 +1,40 @@
+---
+title: "QR food ordering guest experience"
+description: "How the QR food ordering web app presents menus, dining options, availability, and prices to guests."
+lead: ""
+date: 2026-07-07T00:00:00+00:00
+lastmod: 2026-07-07T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: ""
+    identifier: "qr_food_order-3a7c9e21b45d4f8ea0c6d2f18e73b904"
+weight: 343
+toc: true
+type: docs
+---
+
+This article explains how the QR food ordering web app behaves for guests, so you know what to expect from the setup you configure in Business Central.
+
+## Dining options and menus
+
+Menus are dining-option aware. When a guest selects a dining option (for example **dine-in** or **take-away**), the app shows the menu that matches that option. This lets you present different items or prices per dining option from the same restaurant.
+
+Each dining option is tied to a **VAT business posting group**, which the app passes when it fetches the menu. Make sure every dining option you offer has a VAT business posting group configured, otherwise the menu cannot be loaded for that option.
+
+## Menu availability by time zone
+
+Menus can be limited to availability windows (for example a lunch menu that is only shown during lunch hours). Availability is evaluated in the **restaurant's local time zone**, not the guest's device time zone, so a menu opens and closes at the intended local time regardless of where the guest is.
+
+If a restaurant has no menu currently within its availability window, the app treats the restaurant as closed for ordering until the next window opens.
+
+## Prices and item presentation
+
+- **Free items and ingredients.** When an ingredient has no additional cost, the app shows a translatable **Free** label instead of a `0.00` amount, so guests are not shown a zero price.
+- **Long descriptions.** Item descriptions that exceed the visible area are collapsed with a **Show more / Show less** toggle. Short descriptions are shown in full. This keeps long, richly formatted descriptions readable without pushing ordering controls off screen.
+- **Page title.** The browser tab title is set to the selected restaurant's name, falling back to *Tableside* when no restaurant is selected.
+
+## Related API changes
+
+The QR food ordering and self-service proxy also expose a POS sale park endpoint and a menu VAT parameter. See [<ins>POS Sale API: park and resume<ins>]({{< ref "../../../retail/pos_processes/reference/pos_sale_api/index.md" >}}) for the park/resume behavior used by the payment-recovery flow.

--- a/content/en/docs/hospitality/how-to/self_service_kiosk_operator_flow/index.md
+++ b/content/en/docs/hospitality/how-to/self_service_kiosk_operator_flow/index.md
@@ -37,6 +37,20 @@ A kiosk refresh should continue the active sale/session flow, rather than starti
 
 While membership validation is running, the kiosk shows a loading spinner so users and operators can see that processing is still in progress. Operators should wait for this validation to finish before retrying actions, because repeated clicks can create duplicate requests.
 
+## Locked kiosk on payment failure
+
+If a customer's payment is taken but the order cannot be completed on the kiosk, the kiosk locks itself and shows a **needs assistance** screen asking the customer to ask a staff member for help. This prevents the customer from retrying and paying twice.
+
+In this situation the sale is parked so it can be completed by staff on the POS rather than lost. The locked state persists across a page reload, so the kiosk stays on the assistance screen until staff clear it.
+
+To recover, staff use the **Refresh Kiosk** control in the staff menu. This clears the locked state and returns the kiosk to normal operation. When the sale was parked, refreshing keeps the parked sale intact so it can still be completed on the POS.
+
+{{< alert icon="📝" text="The <b>Cancel payment</b> button is not shown while a payment is being processed, so customers cannot interrupt an in-progress payment."/>}}
+
+## Category descriptions on the product list
+
+Product categories on the kiosk product list show their description below the category title when one is set. Descriptions are shown in the customer's selected language, so maintain localized category descriptions to guide customers through the menu.
+
 ## Troubleshooting
 
 If kiosk behavior is not as expected, start by checking whether tenant configuration is loaded correctly, including dining options and language settings. Then confirm that kiosk mode can retrieve active sale/session state after refresh and that connectivity to backend services is stable for both sale retrieval and membership validation. While the issue is being investigated, you can temporarily switch the kiosk to **Out of Order** to prevent customers from entering an unstable flow.

--- a/content/en/docs/hospitality/reference/menu_items/index.md
+++ b/content/en/docs/hospitality/reference/menu_items/index.md
@@ -1,0 +1,36 @@
+---
+title: "Restaurant menu items"
+description: "Reference for menu item availability status and the routing profile requirement on NPRE menu items."
+lead: ""
+date: 2026-07-07T00:00:00+00:00
+lastmod: 2026-07-07T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: ""
+    identifier: "menu_items-8d20f4a1c9b64e07af1e5c3d20976b18"
+weight: 116
+toc: true
+type: docs
+---
+
+Menu items are the items you make orderable in a restaurant menu. This page documents two settings that control whether an item can be added to a menu and whether guests can see and order it.
+
+## Status
+
+Each menu item has a **Status** field that controls its visibility and orderability. It is shown on the menu items list and on the menu items part of a menu category.
+
+| Status | Behavior |
+| --- | --- |
+| **Active** | The item is shown on the menu and can be ordered. |
+| **Inactive (visible)** | The item is shown on the menu but cannot be ordered (for example, temporarily sold out). |
+| **Inactive (hidden)** | The item is not shown on the menu. |
+
+Use **Inactive (visible)** when you want guests to still see an item that is temporarily unavailable, and **Inactive (hidden)** to remove it from the menu without deleting it.
+
+## Routing profile requirement
+
+An item can only be added to a restaurant menu if the item card has a **Rest. Item Routing Profile** set. If the field is blank, adding or changing the item on a menu is blocked with an error asking you to set the item's routing profile first.
+
+This prevents menu items that have no kitchen routing, which would otherwise be silently skipped when orders are sent to the kitchen. Set the routing profile on the item before adding it to a menu — see [<ins>Restaurant item routing profiles<ins>]({{< ref "../../explanation/routing_profiles/index.md" >}}).

--- a/content/en/docs/retail/pos_processes/reference/pos_sale_api/index.md
+++ b/content/en/docs/retail/pos_processes/reference/pos_sale_api/index.md
@@ -1,0 +1,68 @@
+---
+title: "POS Sale API: park and resume"
+description: "Park an in-progress POS sale for later and resume it on any open POS unit through the POS Sale API."
+lead: ""
+date: 2026-07-07T00:00:00+00:00
+lastmod: 2026-07-07T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: ""
+    identifier: "pos_sale_api-6b1f0a2c4d7e4b98a1c3e5f70918ab24"
+weight: 116
+toc: true
+type: docs
+---
+
+The POS Sale API lets an external client (for example a self-service kiosk or a QR food ordering app) park an active POS sale so it can be finished later, and resume a parked sale on an open POS unit. It is the API used behind the self-service *save sale for later* and payment-recovery flows.
+
+## Park a sale
+
+```text
+POST /pos/sale/{saleId}/park
+```
+
+Parks the active sale identified by `{saleId}`. No request body is required.
+
+When called, the sale is saved as a **Saved Sale Entry** and the live POS sale is removed. The POS unit that owns the sale must be open, otherwise the request is rejected.
+
+A successful call returns **201** with:
+
+| Field | Description |
+| --- | --- |
+| `saleId` | System ID of the new Saved Sale Entry. Use this value to resume the sale. |
+| `receiptNo` | Sales ticket number of the parked sale. |
+| `posUnit` | The POS unit (register number) the sale was parked from. |
+| `parkedAt` | Timestamp when the sale was parked. |
+
+{{< alert icon="❗" text="The <code>saleId</code> returned by park is a <b>new</b> identifier (the Saved Sale Entry). It is not the same as the original sale ID, and it is the value you must pass to the resume endpoint."/>}}
+
+## Resume a sale
+
+```text
+POST /pos/sale/{saleId}/resume
+```
+
+Resumes the parked sale identified by the Saved Sale Entry `{saleId}`. A JSON body is required:
+
+```json
+{ "posUnit": "<POS unit number>" }
+```
+
+The requested POS unit must be open. The sale is rebuilt as an active POS sale on that unit and the Saved Sale Entry is removed. A successful call returns **201** with the full POS sale, including its lines.
+
+A sale can be resumed on a **different** POS unit than the one it was parked on, which enables hand-off between registers.
+
+## Requirements
+
+- The API user must have a **User Setup** record with a POS unit assigned. Requests fail if no POS unit can be resolved for the user.
+- Both endpoints validate that the target POS unit is open before parking or resuming.
+
+## Common responses
+
+| Status | Meaning |
+| --- | --- |
+| `201` | Sale parked / resumed. |
+| `400` | Missing or invalid `saleId`, missing `posUnit` on resume, or the POS unit is not open. |
+| `404` | No matching sale (park) or Saved Sale Entry (resume) was found. |

--- a/content/en/docs/retail/posting_setup/how-to/job_queue_refresher/index.md
+++ b/content/en/docs/retail/posting_setup/how-to/job_queue_refresher/index.md
@@ -139,6 +139,8 @@ Assigning a runner user:
 3.	Select a Monitored Job.
 4.	Set the **Job Queue Runner User Name** field.
 
+{{< alert icon="📝" text="When you look up a runner user (on <b>Default Refresher User Name</b> or on a monitored job's <b>JQ Runner User Name</b>), the picker now lists only <b>Job Queue Runner Users</b> that are actually registered for the external refresher, filtered to those below the <b>Failed Attempts</b> limit. Entra Applications that are not operational refresher users no longer appear in the lookup."/>}}
+
 To review all the existing Job Queue Runner users, open the page under Actions → External JQ Refresher → [**Show External JQ Refresher Users**](#job-queue-runner-users).
 
 ### Set up Monitored Jobs


### PR DESCRIPTION
Documents the highest-priority ("must document now") undocumented setup and behavioral product changes identified in DOC-321, from the last window of commits across npcore, the QR/self-service food apps, Entria and Shopify. Details were verified against the actual source commits, so a few recap assumptions were corrected (see note below).

**New pages**
- **POS Sale API: park & resume** (`retail/pos_processes/reference/pos_sale_api`) — `POST /pos/sale/{saleId}/park` and `/resume`, including the resume `posUnit` body, cross-unit hand-off, and the User Setup requirement.
- **QR food ordering guest experience** (`hospitality/how-to/qr_food_order`) — dining-option-aware menus, restaurant-timezone availability, Free labels, expandable descriptions, page title.
- **Restaurant menu items** (`hospitality/reference/menu_items`) — the `Status` field (Active / Inactive (visible) / Inactive (hidden)) and the routing-profile requirement.
- **Digital notifications for e-commerce orders** (`ecommerce/digital_notifications`) — consolidated manifest email now covering coupons and attraction wallets, the `NPR EcomDigitalNotifJQ` job queue, and the exclude-from-manifest flags.
- **Entria order import & sync state** and **Entria checkout language & locale** (`ecommerce/entria/how-to`).

**Updates**
- `routing_profiles` — routing profile now required to add an item to a menu.
- `job_queue_refresher` — runner-user picker now lists only registered Job Queue Runner Users below the Failed Attempts limit.
- Shopify `getting_orders` — reservation token written to order attribute + `np-ticket` metafields.
- Entria `voucher_checkout` — voucher product amount limits (min / max / price steps).
- Self-service kiosk — locked-kiosk flow on payment failure, hidden Cancel payment button, localized category descriptions.

**Corrections vs. the recap thread** (worth a reviewer's eye): the Shopify "alt-tag matching" claim was not in the source — dynamic pricing matches on a `variant_tags` metaobject field, so it is not documented here; the locked-kiosk screen is a customer "ask staff" page, not a staff receipt; the `/me` field is `selfserviceProfile`; and "Free" applies to ingredients.

Scope is the must-document-now set. Should-document-soon and developer/reference-only items (e.g. Shopify dynamic-price mapping internals, membership lifecycle API fields, BC REST proxy header) are left for follow-ups and noted on the issue.